### PR TITLE
Build/appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -27,9 +27,12 @@ install:
   #- cmd: dir DeepFaceLab*
   - cmd: dir
   - cmd: dir .\deepfacelab
-  - cmd: dir .\DeepFaceLab*\_internal\DeepFaceLab
-  - cmd: xcopy .\deepfacelab .\DeepFaceLab*\_internal\DeepFaceLab\ /Y /O /X /E /H /K
-  - cmd: 7z a DeepFaceLab%ARCH%.7z -r DeepFaceLab*\
+  - cmd: dir .\DeepFaceLab%ARCH%\_internal\DeepFaceLab
+  - cmd: xcopy .\deepfacelab .\DeepFaceLab%ARCH%\_internal\DeepFaceLab\ /Y /O /X /E /H /K
+  - cmd: For /f "tokens=2-4 delims=/ " %%a in ('date /t') do (set mydate=%%c-%%a-%%b)
+  - cmd: set /p ARCHIVE_NAME=DeepFaceLab-%ARCH%-%mydate%-%APPVEYOR_REPO_BRANCH%-%APPVEYOR_BUILD_NUMBER%
+  - cmd: echo %ARCHIVE_NAME%
+  - cmd: 7z a %ARCHIVE_NAME%.7z -r DeepFaceLab*\
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,7 @@ install:
   #- cmd: 7z l prebuilt.zip
   - cmd: 7z e prebuilt.zip -y > nul
   #- cmd: dir DeepFaceLab*
+  - cmd: dir
   - cmd: xcopy \deepfacelab \DeepFaceLab*\_internal\deepfacelab\ /Y /O /X /E /H /K
   - cmd: 7z a DeepFaceLab%ARCH%.7z -r DeepFaceLab*\
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -55,7 +55,7 @@ build: off
 #  - '%PYTHON%\python.exe setup.py bdist_wheel'
 
 artifacts:
-  - path: DeepFaceLab%ARCH%.zip
+  - path: %ARCHIVE_NAME%.7z
 
 #on_success:
 #  You can use this step to upload your artifacts to a public website.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -28,6 +28,7 @@ install:
   - cmd: dir
   - cmd: dir .\deepfacelab
   - cmd: dir .\DeepFaceLab%ARCH%\_internal\DeepFaceLab
+  - cmd: rmdir /q/ s .\DeepFaceLab%ARCH%\_internal\DeepFaceLab
   - cmd: xcopy .\deepfacelab .\DeepFaceLab%ARCH%\_internal\DeepFaceLab\ /Y /O /X /E /H /K
   - cmd: For /f "tokens=2-4 delims=/ " %%a in ('date /t') do (set mydate=%%c-%%a-%%b)
   - cmd: set /p ARCHIVE_NAME=DeepFaceLab-%ARCH%-%mydate%-%APPVEYOR_REPO_BRANCH%-%APPVEYOR_BUILD_NUMBER%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,8 +15,8 @@ version: '{branch}-{build}'
 install:
   - cmd: SET PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%"
   #- cmd: For /f "tokens=2-4 delims=/ " %%a in ('date /t') do (set mydate=%%c-%%a-%%b)
-  - cmd: set /p mydate=2019-09-11
-  - cmd: set /p ARCHIVE_NAME=DeepFaceLab-%ARCH%-%mydate%-%APPVEYOR_REPO_BRANCH%-%APPVEYOR_BUILD_NUMBER%
+  - cmd: set mydate=2019-09-11
+  - cmd: set ARCHIVE_NAME=DeepFaceLab-%ARCH%-%mydate%-%APPVEYOR_REPO_BRANCH%-%APPVEYOR_BUILD_NUMBER%
   - cmd: echo %ARCHIVE_NAME%
   - ps: python --version
   - ps: python -m pip install --upgrade pip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ version: '{branch}-{build}'
 
 install:
   # Download the latest prebuilt exe
-  - URL=$(python ./appveyor/gdrive.py $ARCH)
+  - set URL=$(python ./appveyor/gdrive.py $ARCH)
   - echo $URL
 
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ install:
   #- cmd: 7z l prebuilt.zip
   - cmd: 7z e prebuilt.zip -y > nul
   #- cmd: dir DeepFaceLab*
-  - cmd: xcopy deepfacelab DeepFaceLab*\_internal\*  /O /X /E /H /K
+  - cmd: xcopy "deepfacelab\*" "DeepFaceLab*\_internal\"  /Y /O /X /E /H /K
   - cmd: 7z a DeepFaceLab%ARCH%.7z -r DeepFaceLab\
 
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ install:
   - cmd: set /p URL=<Output
   - ps: wget "$env:URL" -OutFile prebuilt.zip
   #- cmd: 7z l prebuilt.zip
-  - cmd: 7z e prebuilt.zip -y > nul
+  - cmd: 7z x prebuilt.zip -y > nul
   #- cmd: dir DeepFaceLab*
   - cmd: dir
   - cmd: xcopy \deepfacelab \DeepFaceLab*\_internal\deepfacelab\ /Y /O /X /E /H /K

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,7 @@ install:
   - cmd: xcopy .\deepfacelab .\DeepFaceLab%ARCH%\_internal\DeepFaceLab\ /Y /O /X /E /H /K
   - cmd: dir .\DeepFaceLab%ARCH%\_internal
   - cmd: dir .\DeepFaceLab%ARCH%\_internal\DeepFaceLab
-  - cmd: 7z a %ARCHIVE_NAME%.zip -tzip -mx=1 -r DeepFaceLab%ARCH%\
+  - cmd: 7z a %ARCHIVE_NAME%.7z -tzip -mx=1 -r DeepFaceLab%ARCH%\
 
 build: off
 
@@ -55,7 +55,7 @@ build: off
 #  - '%PYTHON%\python.exe setup.py bdist_wheel'
 
 artifacts:
-  - path: %ARCHIVE_NAME%.zip
+  - path: "%ARCHIVE_NAME%.7z"
 
 #on_success:
 #  You can use this step to upload your artifacts to a public website.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,8 +26,8 @@ install:
   #- cmd: dir %home%\deepfacelab\appveyor
   - cmd: python deepfacelab\appveyor\gdrive.py %ARCH% > Output
   - cmd: set /p URL=<Output
-  - cmd: echo %URL%
-  - ps: wget %URL% -OutFile prebuilt.zip
+  #- cmd: echo %URL%
+  - ps: wget "%URL%" -OutFile prebuilt.zip
   - cmd: 7z e prebuilt.zip -y > nul
 
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,8 +14,8 @@ version: '{branch}-{build}'
 
 install:
   - cmd: SET PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%"
-  #- cmd: For /f "tokens=2-4 delims=/ " %%a in ('date /t') do (set mydate=%%c-%%a-%%b)
-  - cmd: set mydate=2019-09-11
+  - cmd: For /f "tokens=2-4 delims=/ " %%a in ('date /t') do (set mydate=%%c-%%a-%%b)
+  #- cmd: set mydate=2019-09-11
   - cmd: set ARCHIVE_NAME=DeepFaceLab-%ARCH%-%mydate%-%APPVEYOR_BUILD_NUMBER%
   - cmd: echo %ARCHIVE_NAME%
   - ps: python --version

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,9 +2,9 @@ environment:
   global:
     PYTHON: "C:\\Python36-x64"
   matrix:
-    # - ARCH: "OpenCLSSE"
-    # - ARCH: "CUDA9.2SSE"
-    # - ARCH: "CUDA10.1SSE"
+    #- ARCH: "OpenCLSSE"
+    #- ARCH: "CUDA9.2SSE"
+    #- ARCH: "CUDA10.1SSE"
     - ARCH: "CUDA10.1AVX"
 
 
@@ -16,12 +16,13 @@ install:
   # Download the latest prebuilt exe
   - cmd: SET PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%"
   - ps: python --version
-  - ps: python -m pip install --upgrade pip
+  #- ps: python -m pip install --upgrade pip
   - ps: python -m pip install -r appveyor/requirements.txt
   - cmd: cd ..
-  - cmd: python %home%/appveyor/gdrive.py %ARCH% > Output
+  - cmd: echo %cd%
+  - cmd: python %home%\appveyor\gdrive.py %ARCH% > Output
   - cmd: set /p URL=<Output
-  - cmd: echo %URL%
+  #- cmd: echo %URL%
   - ps: wget $URL -OutFile prebuilt.zip
   - cmd: 7z e prebuilt.zip -y > nul
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -56,7 +56,7 @@ build: off
 #  - '%PYTHON%\python.exe setup.py bdist_wheel'
 
 artifacts:
-  - path: "..\%ARCHIVE_NAME%.7z"
+  - path: ..\%ARCHIVE_NAME%.7z
 
 #on_success:
 #  You can use this step to upload your artifacts to a public website.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,8 +13,10 @@ version: '{branch}-{build}'
 #os: Visual Studio 2017
 
 install:
-  # Download the latest prebuilt exe
   - cmd: SET PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%"
+  - cmd: For /f "tokens=2-4 delims=/ " %%a in ('date /t') do (set mydate=%%c-%%a-%%b)
+  - cmd: set /p ARCHIVE_NAME=DeepFaceLab-%ARCH%-%mydate%-%APPVEYOR_REPO_BRANCH%-%APPVEYOR_BUILD_NUMBER%
+  - cmd: echo %ARCHIVE_NAME%
   - ps: python --version
   - ps: python -m pip install --upgrade pip
   - ps: python -m pip install -r appveyor/requirements.txt
@@ -23,16 +25,13 @@ install:
   - cmd: set /p URL=<Output
   - ps: wget "$env:URL" -OutFile prebuilt.zip
   - cmd: 7z x prebuilt.zip -y > nul
-  - cmd: dir
-  - cmd: dir .\deepfacelab
-  - cmd: dir .\DeepFaceLab%ARCH%\_internal\DeepFaceLab
-  - cmd: rmdir /q/ s .\DeepFaceLab%ARCH%\_internal\DeepFaceLab
-  - cmd: xcopy .\deepfacelab .\DeepFaceLab%ARCH%\_internal\DeepFaceLab\ /Y /O /X /E /H /K
-  - cmd: For /f "tokens=2-4 delims=/ " %%a in ('date /t') do (set mydate=%%c-%%a-%%b)
-  - cmd: set /p ARCHIVE_NAME=DeepFaceLab-%ARCH%-%mydate%-%APPVEYOR_REPO_BRANCH%-%APPVEYOR_BUILD_NUMBER%
-  - cmd: echo %ARCHIVE_NAME%
-  - cmd: dir .\DeepFaceLab%ARCH%\_internal
-  - cmd: dir .\DeepFaceLab%ARCH%\_internal\DeepFaceLab
+  #- cmd: dir
+  #- cmd: dir .\deepfacelab
+  #- cmd: dir .\DeepFaceLab%ARCH%\_internal\DeepFaceLab
+  #- cmd: rmdir /q/ s .\DeepFaceLab%ARCH%\_internal\DeepFaceLab
+  #- cmd: xcopy .\deepfacelab .\DeepFaceLab%ARCH%\_internal\DeepFaceLab\ /Y /O /X /E /H /K
+  #- cmd: dir .\DeepFaceLab%ARCH%\_internal
+  #- cmd: dir .\DeepFaceLab%ARCH%\_internal\DeepFaceLab
   #- cmd: 7z a %ARCHIVE_NAME%.7z -r DeepFaceLab%ARCH%
 
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,8 @@ version: '{branch}-{build}'
 
 install:
   # Download the latest prebuilt exe
-  - ps: Set-Variable -Name "URL" -Value $(python ./appveyor/gdrive.py $ARCH)
+  - ps: pip install -r appveyor/requirements.txt
+  - ps: Set-Variable -Name "URL" -Value $(python appveyor/gdrive.py $ARCH)
   - ps: Write-Output $URL
   - cmd: cd %home%
   - ps: wget $URL -OutFile prebuilt.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ install:
   - cmd: SET PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%"
   #- cmd: For /f "tokens=2-4 delims=/ " %%a in ('date /t') do (set mydate=%%c-%%a-%%b)
   - cmd: set mydate=2019-09-11
-  - cmd: set ARCHIVE_NAME=DeepFaceLab-%ARCH%-%mydate%-%APPVEYOR_REPO_BRANCH%-%APPVEYOR_BUILD_NUMBER%
+  - cmd: set ARCHIVE_NAME=DeepFaceLab-%ARCH%-%mydate%-%APPVEYOR_BUILD_NUMBER%
   - cmd: echo %ARCHIVE_NAME%
   - ps: python --version
   - ps: python -m pip install --upgrade pip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,7 @@ install:
   - cmd: xcopy .\deepfacelab .\DeepFaceLab%ARCH%\_internal\DeepFaceLab\ /Y /O /X /E /H /K
   - cmd: dir .\DeepFaceLab%ARCH%\_internal
   - cmd: dir .\DeepFaceLab%ARCH%\_internal\DeepFaceLab
-  - cmd: 7z a %ARCHIVE_NAME%.7z -tzip -mx=1 -r DeepFaceLab%ARCH%\
+  - cmd: 7z a .\deepfacelab\%ARCHIVE_NAME%.7z -tzip -mx=1 -r DeepFaceLab%ARCH%\
   - cmd: dir
 
 build: off
@@ -56,7 +56,7 @@ build: off
 #  - '%PYTHON%\python.exe setup.py bdist_wheel'
 
 artifacts:
-  - path: ..\%ARCHIVE_NAME%.7z
+  - path: .\%ARCHIVE_NAME%.7z
 
 #on_success:
 #  You can use this step to upload your artifacts to a public website.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
   global:
-    PYTHON: "C:\Python36-x64"
+    PYTHON: "C:\\Python36-x64"
   matrix:
     # - ARCH: "OpenCLSSE"
     # - ARCH: "CUDA9.2SSE"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,9 +26,9 @@ install:
   - cmd: 7z x prebuilt.zip -y > nul
   #- cmd: dir DeepFaceLab*
   - cmd: dir
-  - cmd: dir %home%\deepfacelab
-  - cmd: dir %home%\DeepFaceLab*\_internal\DeepFaceLab
-  - cmd: xcopy %home%\deepfacelab %home%\DeepFaceLab*\_internal\DeepFaceLab\ /Y /O /X /E /H /K
+  - cmd: dir .\deepfacelab
+  - cmd: dir .\DeepFaceLab*\_internal\DeepFaceLab
+  - cmd: xcopy .\deepfacelab .\DeepFaceLab*\_internal\DeepFaceLab\ /Y /O /X /E /H /K
   - cmd: 7z a DeepFaceLab%ARCH%.7z -r DeepFaceLab*\
 
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,8 @@ install:
   - cmd: For /f "tokens=2-4 delims=/ " %%a in ('date /t') do (set mydate=%%c-%%a-%%b)
   - cmd: set /p ARCHIVE_NAME=DeepFaceLab-%ARCH%-%mydate%-%APPVEYOR_REPO_BRANCH%-%APPVEYOR_BUILD_NUMBER%
   - cmd: echo %ARCHIVE_NAME%
-  - cmd: 7z a %ARCHIVE_NAME%.7z -r DeepFaceLab*\
+  - cmd: dir .\DeepFaceLab%ARCH%\_internal\DeepFaceLab
+  - cmd: 7z a %ARCHIVE_NAME%.7z -r DeepFaceLab%ARCH%
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ install:
   - cmd: 7z e prebuilt.zip -y > nul
   #- cmd: dir DeepFaceLab*
   - cmd: xcopy deepfacelab\* DeepFaceLab*\_internal\deepfacelab  /Y /O /X /E /H /K
-  - cmd: 7z a DeepFaceLab%ARCH%.7z -r DeepFaceLab\
+  - cmd: 7z a DeepFaceLab%ARCH%.7z -r DeepFaceLab*\
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,9 +22,9 @@ install:
   - cmd: echo %cd%
   - cmd: dir
   - cmd: dir %home%
-  - cmd: dir %home%\DeepFaceLab
-  - cmd: dir %home%\DeepFaceLab\appveyor
-  - cmd: python %home%\DeepFaceLab\appveyor\gdrive.py %ARCH% > Output
+  - cmd: dir %home%\deepfacelab
+  - cmd: dir %home%\deepfacelab\appveyor
+  - cmd: python %home%\deepfacelab\appveyor\gdrive.py %ARCH% > Output
   - cmd: set /p URL=<Output
   #- cmd: echo %URL%
   - ps: wget $URL -OutFile prebuilt.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ install:
   #- cmd: 7z l prebuilt.zip
   - cmd: 7z e prebuilt.zip -y > nul
   #- cmd: dir DeepFaceLab*
-  - cmd: xcopy deepfacelab DeepFaceLab*\_internal\deepfacelab  /O /X /E /H /K
+  - cmd: xcopy deepfacelab DeepFaceLab*\_internal\*  /O /X /E /H /K
   - cmd: 7z a DeepFaceLab%ARCH%.7z -r DeepFaceLab\
 
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ install:
   #- cmd: 7z l prebuilt.zip
   - cmd: 7z e prebuilt.zip -y > nul
   #- cmd: dir DeepFaceLab*
-  - cmd: xcopy "deepfacelab\*" "DeepFaceLab*\_internal\"  /Y /O /X /E /H /K
+  - cmd: xcopy deepfacelab\* DeepFaceLab*\_internal\deepfacelab  /Y /O /X /E /H /K
   - cmd: 7z a DeepFaceLab%ARCH%.7z -r DeepFaceLab\
 
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ install:
   #- cmd: 7z l prebuilt.zip
   - cmd: 7z e prebuilt.zip -y > nul
   #- cmd: dir DeepFaceLab*
-  - cmd: xcopy deepfacelab\* DeepFaceLab*\_internal\deepfacelab  /Y /O /X /E /H /K
+  - cmd: xcopy deepfacelab\* DeepFaceLab*\_internal\deepfacelab\ /Y /O /X /E /H /K
   - cmd: 7z a DeepFaceLab%ARCH%.7z -r DeepFaceLab*\
 
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ install:
   #- cmd: 7z l prebuilt.zip
   - cmd: 7z e prebuilt.zip -y > nul
   #- cmd: dir DeepFaceLab*
-  - cmd: xcopy deepfacelab\* DeepFaceLab*\_internal\deepfacelab\ /Y /O /X /E /H /K
+  - cmd: xcopy deepfacelab DeepFaceLab*\_internal\deepfacelab\ /Y /O /X /E /H /K
   - cmd: 7z a DeepFaceLab%ARCH%.7z -r DeepFaceLab*\
 
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -34,6 +34,7 @@ install:
   - cmd: dir .\DeepFaceLab%ARCH%\_internal
   - cmd: dir .\DeepFaceLab%ARCH%\_internal\DeepFaceLab
   - cmd: 7z a %ARCHIVE_NAME%.7z -tzip -mx=1 -r DeepFaceLab%ARCH%\
+  - cmd: dir
 
 build: off
 
@@ -55,7 +56,7 @@ build: off
 #  - '%PYTHON%\python.exe setup.py bdist_wheel'
 
 artifacts:
-  - path: "%ARCHIVE_NAME%.7z"
+  - path: "..\%ARCHIVE_NAME%.7z"
 
 #on_success:
 #  You can use this step to upload your artifacts to a public website.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,7 +20,7 @@ install:
   - ps: python -m pip install -r appveyor/requirements.txt
   - cmd: cd ..
   - cmd: echo %cd%
-  - cmd: python %home%\appveyor\gdrive.py %ARCH% > Output
+  - cmd: python %home%\DeepFaceLab\appveyor\gdrive.py %ARCH% > Output
   - cmd: set /p URL=<Output
   #- cmd: echo %URL%
   - ps: wget $URL -OutFile prebuilt.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,6 +20,10 @@ install:
   - ps: python -m pip install -r appveyor/requirements.txt
   - cmd: cd ..
   - cmd: echo %cd%
+  - cmd: dir
+  - cmd: dir %home%
+  - cmd: dir %home%\DeepFaceLab
+  - cmd: dir %home%\DeepFaceLab\appveyor
   - cmd: python %home%\DeepFaceLab\appveyor\gdrive.py %ARCH% > Output
   - cmd: set /p URL=<Output
   #- cmd: echo %URL%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ install:
   # Download the latest prebuilt exe
   - cmd: SET PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%"
   - ps: python --version
-  #- ps: python -m pip install --upgrade pip
+  - ps: python -m pip install --upgrade pip
   - ps: python -m pip install -r appveyor/requirements.txt
   - cmd: cd ..
   - cmd: echo %cd%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,7 +18,7 @@ install:
   - ps: python --version
   - ps: python -m pip install --upgrade pip
   - ps: python -m pip install -r appveyor/requirements.txt
-  #- cmd: cd ..
+  - cmd: cd ..
   #- cmd: echo %cd%
   #- cmd: dir
   #- cmd: dir %home%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,9 +11,11 @@ version: '{branch}-{build}'
 
 install:
   # Download the latest prebuilt exe
-  - set URL=$(python ./appveyor/gdrive.py $ARCH)
-  - cd ..
-  - wget $URL
+  - ps: Set-Variable -Name "URL" -Value $(python ./appveyor/gdrive.py $ARCH)
+  - ps: Write-Output $URL
+  - cmd: cd %home%
+  - ps: wget $URL -OutFile prebuilt.zip
+  - cmd: 7z e prebuilt.zip -y > nul
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,12 @@
 environment:
+  global:
+    PYTHON: "C:\\Python36-x64"
   matrix:
     # - ARCH: "OpenCLSSE"
     # - ARCH: "CUDA9.2SSE"
     # - ARCH: "CUDA10.1SSE"
     - ARCH: "CUDA10.1AVX"
+
 
 version: '{branch}-{build}'
 
@@ -11,8 +14,9 @@ version: '{branch}-{build}'
 
 install:
   # Download the latest prebuilt exe
-  - ps: pip install --user --upgrade pip
-  - ps: pip install --user -r appveyor/requirements.txt
+  - cmd: SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+  - ps: python -m pip install --upgrade pip
+  - ps: python -m pip install -r appveyor/requirements.txt
   - ps: Set-Variable -Name "URL" -Value $(python appveyor/gdrive.py $ARCH)
   - ps: Write-Output $URL
   - cmd: cd ..

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,9 +22,7 @@ install:
   - cmd: python deepfacelab\appveyor\gdrive.py %ARCH% > Output
   - cmd: set /p URL=<Output
   - ps: wget "$env:URL" -OutFile prebuilt.zip
-  #- cmd: 7z l prebuilt.zip
   - cmd: 7z x prebuilt.zip -y > nul
-  #- cmd: dir DeepFaceLab*
   - cmd: dir
   - cmd: dir .\deepfacelab
   - cmd: dir .\DeepFaceLab%ARCH%\_internal\DeepFaceLab
@@ -33,8 +31,9 @@ install:
   - cmd: For /f "tokens=2-4 delims=/ " %%a in ('date /t') do (set mydate=%%c-%%a-%%b)
   - cmd: set /p ARCHIVE_NAME=DeepFaceLab-%ARCH%-%mydate%-%APPVEYOR_REPO_BRANCH%-%APPVEYOR_BUILD_NUMBER%
   - cmd: echo %ARCHIVE_NAME%
+  - cmd: dir .\DeepFaceLab%ARCH%\_internal
   - cmd: dir .\DeepFaceLab%ARCH%\_internal\DeepFaceLab
-  - cmd: 7z a %ARCHIVE_NAME%.7z -r DeepFaceLab%ARCH%
+  #- cmd: 7z a %ARCHIVE_NAME%.7z -r DeepFaceLab%ARCH%
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,9 +22,9 @@ install:
   - cmd: echo %cd%
   - cmd: dir
   - cmd: dir %home%
-  - cmd: dir %home%\deepfacelab
-  - cmd: dir %home%\deepfacelab\appveyor
-  - cmd: python %home%\deepfacelab\appveyor\gdrive.py %ARCH% > Output
+  #- cmd: dir %home%\deepfacelab
+  #- cmd: dir %home%\deepfacelab\appveyor
+  - cmd: python deepfacelab\appveyor\gdrive.py %ARCH% > Output
   - cmd: set /p URL=<Output
   #- cmd: echo %URL%
   - ps: wget $URL -OutFile prebuilt.zip

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,9 +26,9 @@ install:
   - cmd: 7z x prebuilt.zip -y > nul
   #- cmd: dir DeepFaceLab*
   - cmd: dir
-  - cmd: dir \deepfacelab
-  - cmd: dir \DeepFaceLab*\_internal\DeepFaceLab
-  - cmd: xcopy \deepfacelab \DeepFaceLab*\_internal\DeepFaceLab\ /Y /O /X /E /H /K
+  - cmd: dir %home%\deepfacelab
+  - cmd: dir %home%\DeepFaceLab*\_internal\DeepFaceLab
+  - cmd: xcopy %home%\deepfacelab %home%\DeepFaceLab*\_internal\DeepFaceLab\ /Y /O /X /E /H /K
   - cmd: 7z a DeepFaceLab%ARCH%.7z -r DeepFaceLab*\
 
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,7 @@ install:
   #- cmd: dir %home%\deepfacelab\appveyor
   - cmd: python deepfacelab\appveyor\gdrive.py %ARCH% > Output
   - cmd: set /p URL=<Output
-  #- cmd: echo %URL%
+  - cmd: echo %URL%
   - ps: wget %URL% -OutFile prebuilt.zip
   - cmd: 7z e prebuilt.zip -y > nul
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ install:
   #- cmd: 7z l prebuilt.zip
   - cmd: 7z e prebuilt.zip -y > nul
   #- cmd: dir DeepFaceLab*
-  - cmd: xcopy deepfacelab DeepFaceLab*\_internal\deepfacelab\ /Y /O /X /E /H /K
+  - cmd: xcopy .\deepfacelab .\DeepFaceLab*\_internal\deepfacelab\ /Y /O /X /E /H /K
   - cmd: 7z a DeepFaceLab%ARCH%.7z -r DeepFaceLab*\
 
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,7 +12,8 @@ version: '{branch}-{build}'
 install:
   # Download the latest prebuilt exe
   - set URL=$(python ./appveyor/gdrive.py $ARCH)
-  - echo $URL
+  - cd ..
+  - wget $URL
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,7 @@ install:
   - cmd: xcopy .\deepfacelab .\DeepFaceLab%ARCH%\_internal\DeepFaceLab\ /Y /O /X /E /H /K
   - cmd: dir .\DeepFaceLab%ARCH%\_internal
   - cmd: dir .\DeepFaceLab%ARCH%\_internal\DeepFaceLab
-  - cmd: 7z a %ARCHIVE_NAME%.7z -r DeepFaceLab%ARCH%
+  - cmd: 7z a %ARCHIVE_NAME%.7z -r DeepFaceLab%ARCH%\
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,7 @@ install:
   - cmd: xcopy .\deepfacelab .\DeepFaceLab%ARCH%\_internal\DeepFaceLab\ /Y /O /X /E /H /K
   - cmd: dir .\DeepFaceLab%ARCH%\_internal
   - cmd: dir .\DeepFaceLab%ARCH%\_internal\DeepFaceLab
-  - cmd: 7z a %ARCHIVE_NAME%.7z -tzip -mx=1 -r DeepFaceLab%ARCH%\
+  - cmd: 7z a %ARCHIVE_NAME%.zip -tzip -mx=1 -r DeepFaceLab%ARCH%\
 
 build: off
 
@@ -55,7 +55,7 @@ build: off
 #  - '%PYTHON%\python.exe setup.py bdist_wheel'
 
 artifacts:
-  - path: %ARCHIVE_NAME%.7z
+  - path: %ARCHIVE_NAME%.zip
 
 #on_success:
 #  You can use this step to upload your artifacts to a public website.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 environment:
   global:
-    PYTHON: "C:\\Python36-x64"
+    PYTHON: "C:\Python36-x64"
   matrix:
     # - ARCH: "OpenCLSSE"
     # - ARCH: "CUDA9.2SSE"
@@ -14,7 +14,7 @@ version: '{branch}-{build}'
 
 install:
   # Download the latest prebuilt exe
-  - cmd: SET PATH=%PYTHON%;%PYTHON%\\Scripts;%PATH%"
+  - cmd: SET PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%"
   - ps: python -m pip install --upgrade pip
   - ps: python -m pip install -r appveyor/requirements.txt
   - ps: Set-Variable -Name "URL" -Value $(python appveyor/gdrive.py $ARCH)

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,21 +2,28 @@ environment:
   global:
     PYTHON: "C:\\Python36-x64"
   matrix:
-    #- ARCH: "OpenCLSSE"
-    #- ARCH: "CUDA9.2SSE"
-    #- ARCH: "CUDA10.1SSE"
+    - ARCH: "OpenCLSSE"
+    - ARCH: "CUDA9.2SSE"
+    - ARCH: "CUDA10.1SSE"
     - ARCH: "CUDA10.1AVX"
 
 
 version: '{branch}-{build}'
 
-#os: Visual Studio 2017
+#os: Visual Studio 2015
+
+## build cache to preserve files/folders between builds
+#cache:
+#  - packages -> **\packages.config  # preserve "packages" directory in the root of build folder but will reset it if packages.config is modified
+#  - projectA\libs
+#  - node_modules                    # local npm modules
+#  - '%LocalAppData%\NuGet\Cache'    # NuGet < v3
+#  - '%LocalAppData%\NuGet\v3-cache' # NuGet v3
 
 install:
   - cmd: SET PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%"
   - cmd: For /f "tokens=2-4 delims=/ " %%a in ('date /t') do (set mydate=%%c-%%a-%%b)
-  #- cmd: set mydate=2019-09-11
-  - cmd: set ARCHIVE_NAME=DeepFaceLab-%ARCH%-%mydate%-%APPVEYOR_BUILD_NUMBER%
+  - cmd: set ARCHIVE_NAME=DeepFaceLab-%ARCH%-%mydate%-BUILD-%APPVEYOR_BUILD_NUMBER%
   - cmd: echo %ARCHIVE_NAME%
   - ps: python --version
   - ps: python -m pip install --upgrade pip
@@ -36,24 +43,14 @@ install:
   - cmd: 7z a .\deepfacelab\%ARCHIVE_NAME%.7z -tzip -mx=1 -r DeepFaceLab%ARCH%\
   - cmd: dir
 
-build: off
+build: false
 
 #test_script:
 #  # Put your test command here.
-#  # If you don't need to build C extensions on 64-bit Python 3.3 or 3.4,
-#  # you can remove "build.cmd" from the front of the command, as it's
-#  # only needed to support those cases.
-#  # Note that you must use the environment variable %PYTHON% to refer to
-#  # the interpreter you're using - Appveyor does not do anything special
-#  # to put the Python version you want to use on PATH.
-#  - '%PYTHON%\\python.exe setup.py test'
+#  - test
 
 #after_test:
-#  # This step builds your wheels.
-#  # Again, you only need build.cmd if you're building C extensions for
-#  # 64-bit Python 3.3/3.4. And you need to use %PYTHON% to get the correct
-#  # interpreter
-#  - '%PYTHON%\python.exe setup.py bdist_wheel'
+#  after test
 
 artifacts:
   - path: .\%ARCHIVE_NAME%.7z
@@ -62,3 +59,19 @@ artifacts:
 #  You can use this step to upload your artifacts to a public website.
 #  See Appveyor's documentation for more details. Or you can simply
 #  access your wheels from the Appveyor "artifacts" tab for your build.
+
+#---------------------------------#
+#     deployment configuration    #
+#---------------------------------#
+
+# providers: Local, FTP, WebDeploy, AzureCS, AzureBlob, S3, NuGet, Environment
+# provider names are case-sensitive!
+#deploy:
+#  # Deploy to GitHub Releases
+#  - provider: GitHub
+#    artifact: /.*\.nupkg/           # upload all NuGet packages to release assets
+#    draft: false
+#    prerelease: false
+#    on:
+#      branch: master                # release from master branch only
+#      APPVEYOR_REPO_TAG: true       # deploy on tag push only

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,8 @@ version: '{branch}-{build}'
 
 install:
   - cmd: SET PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%"
-  - cmd: For /f "tokens=2-4 delims=/ " %%a in ('date /t') do (set mydate=%%c-%%a-%%b)
+  #- cmd: For /f "tokens=2-4 delims=/ " %%a in ('date /t') do (set mydate=%%c-%%a-%%b)
+  - cmd: set /p mydate=2019-09-11
   - cmd: set /p ARCHIVE_NAME=DeepFaceLab-%ARCH%-%mydate%-%APPVEYOR_REPO_BRANCH%-%APPVEYOR_BUILD_NUMBER%
   - cmd: echo %ARCHIVE_NAME%
   - ps: python --version
@@ -25,14 +26,14 @@ install:
   - cmd: set /p URL=<Output
   - ps: wget "$env:URL" -OutFile prebuilt.zip
   - cmd: 7z x prebuilt.zip -y > nul
-  #- cmd: dir
-  #- cmd: dir .\deepfacelab
-  #- cmd: dir .\DeepFaceLab%ARCH%\_internal\DeepFaceLab
-  #- cmd: rmdir /q/ s .\DeepFaceLab%ARCH%\_internal\DeepFaceLab
-  #- cmd: xcopy .\deepfacelab .\DeepFaceLab%ARCH%\_internal\DeepFaceLab\ /Y /O /X /E /H /K
-  #- cmd: dir .\DeepFaceLab%ARCH%\_internal
-  #- cmd: dir .\DeepFaceLab%ARCH%\_internal\DeepFaceLab
-  #- cmd: 7z a %ARCHIVE_NAME%.7z -r DeepFaceLab%ARCH%
+  - cmd: dir
+  - cmd: dir .\deepfacelab
+  - cmd: dir .\DeepFaceLab%ARCH%\_internal\DeepFaceLab
+  - cmd: rmdir /q/ s .\DeepFaceLab%ARCH%\_internal\DeepFaceLab
+  - cmd: xcopy .\deepfacelab .\DeepFaceLab%ARCH%\_internal\DeepFaceLab\ /Y /O /X /E /H /K
+  - cmd: dir .\DeepFaceLab%ARCH%\_internal
+  - cmd: dir .\DeepFaceLab%ARCH%\_internal\DeepFaceLab
+  - cmd: 7z a %ARCHIVE_NAME%.7z -r DeepFaceLab%ARCH%
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,7 +33,7 @@ install:
   - cmd: xcopy .\deepfacelab .\DeepFaceLab%ARCH%\_internal\DeepFaceLab\ /Y /O /X /E /H /K
   - cmd: dir .\DeepFaceLab%ARCH%\_internal
   - cmd: dir .\DeepFaceLab%ARCH%\_internal\DeepFaceLab
-  - cmd: 7z a %ARCHIVE_NAME%.7z -r DeepFaceLab%ARCH%\
+  - cmd: 7z a %ARCHIVE_NAME%.7z -tzip -mx=1 -r DeepFaceLab%ARCH%\
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,13 +15,13 @@ version: '{branch}-{build}'
 install:
   # Download the latest prebuilt exe
   - cmd: SET PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%"
-  - cmd: python --version
+  - ps: python --version
   - ps: python -m pip install --upgrade pip
   - ps: python -m pip install -r appveyor/requirements.txt
   - cmd: cd ..
   - cmd: python %home%/appveyor/gdrive.py %ARCH% > Output
   - cmd: set /p URL=<Output
-  - cmd: %URL%
+  - cmd: echo %URL%
   - ps: wget $URL -OutFile prebuilt.zip
   - cmd: 7z e prebuilt.zip -y > nul
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,7 +11,7 @@ version: '{branch}-{build}'
 
 install:
   # Download the latest prebuilt exe
-  - ps: pip install -r appveyor/requirements.txt
+  - ps: python -m pip install -r appveyor/requirements.txt
   - ps: Set-Variable -Name "URL" -Value $(python appveyor/gdrive.py $ARCH)
   - ps: Write-Output $URL
   - cmd: cd %home%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,7 +26,9 @@ install:
   - cmd: 7z x prebuilt.zip -y > nul
   #- cmd: dir DeepFaceLab*
   - cmd: dir
-  - cmd: xcopy \deepfacelab \DeepFaceLab*\_internal\deepfacelab\ /Y /O /X /E /H /K
+  - cmd: dir \deepfacelab
+  - cmd: dir \DeepFaceLab*\_internal\DeepFaceLab
+  - cmd: xcopy \deepfacelab \DeepFaceLab*\_internal\DeepFaceLab\ /Y /O /X /E /H /K
   - cmd: 7z a DeepFaceLab%ARCH%.7z -r DeepFaceLab*\
 
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,43 @@
+environment:
+  matrix:
+    # - ARCH: "OpenCLSSE"
+    # - ARCH: "CUDA9.2SSE"
+    # - ARCH: "CUDA10.1SSE"
+    - ARCH: "CUDA10.1AVX"
+
+version: '{branch}-{build}'
+
+#os: Visual Studio 2017
+
+install:
+  # Download the latest prebuilt exe
+  - URL=$(python ./appveyor/gdrive.py $ARCH)
+  - echo $URL
+
+build: off
+
+#test_script:
+#  # Put your test command here.
+#  # If you don't need to build C extensions on 64-bit Python 3.3 or 3.4,
+#  # you can remove "build.cmd" from the front of the command, as it's
+#  # only needed to support those cases.
+#  # Note that you must use the environment variable %PYTHON% to refer to
+#  # the interpreter you're using - Appveyor does not do anything special
+#  # to put the Python version you want to use on PATH.
+#  - '%PYTHON%\\python.exe setup.py test'
+
+#after_test:
+#  # This step builds your wheels.
+#  # Again, you only need build.cmd if you're building C extensions for
+#  # 64-bit Python 3.3/3.4. And you need to use %PYTHON% to get the correct
+#  # interpreter
+#  - '%PYTHON%\python.exe setup.py bdist_wheel'
+
+#artifacts:
+#  # bdist_wheel puts your built wheel in the dist directory
+#  - path: dist\*
+
+#on_success:
+#  You can use this step to upload your artifacts to a public website.
+#  See Appveyor's documentation for more details. Or you can simply
+#  access your wheels from the Appveyor "artifacts" tab for your build.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,8 +26,11 @@ install:
   #- cmd: dir %home%\deepfacelab\appveyor
   - cmd: python deepfacelab\appveyor\gdrive.py %ARCH% > Output
   - cmd: set /p URL=<Output
+  # test
+  - cmd: set /p FOO=foo
+  - ps: Write-Output $env:FOO
   #- cmd: echo %URL%
-  - ps: wget "%URL%" -OutFile prebuilt.zip
+  - ps: wget $env:URL -OutFile prebuilt.zip
   - cmd: 7z e prebuilt.zip -y > nul
 
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,16 +18,16 @@ install:
   - ps: python --version
   - ps: python -m pip install --upgrade pip
   - ps: python -m pip install -r appveyor/requirements.txt
-  - cmd: cd ..
-  - cmd: echo %cd%
-  - cmd: dir
-  - cmd: dir %home%
+  #- cmd: cd ..
+  #- cmd: echo %cd%
+  #- cmd: dir
+  #- cmd: dir %home%
   #- cmd: dir %home%\deepfacelab
   #- cmd: dir %home%\deepfacelab\appveyor
   - cmd: python deepfacelab\appveyor\gdrive.py %ARCH% > Output
   - cmd: set /p URL=<Output
   #- cmd: echo %URL%
-  - ps: wget $URL -OutFile prebuilt.zip
+  - ps: wget %URL% -OutFile prebuilt.zip
   - cmd: 7z e prebuilt.zip -y > nul
 
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,19 +19,14 @@ install:
   - ps: python -m pip install --upgrade pip
   - ps: python -m pip install -r appveyor/requirements.txt
   - cmd: cd ..
-  #- cmd: echo %cd%
-  #- cmd: dir
-  #- cmd: dir %home%
-  #- cmd: dir %home%\deepfacelab
-  #- cmd: dir %home%\deepfacelab\appveyor
   - cmd: python deepfacelab\appveyor\gdrive.py %ARCH% > Output
   - cmd: set /p URL=<Output
-  # test
-  - cmd: set /p FOO=foo
-  - ps: Write-Output $env:FOO
-  #- cmd: echo %URL%
-  - ps: wget $env:URL -OutFile prebuilt.zip
+  - ps: wget "$env:URL" -OutFile prebuilt.zip
+  - cmd: 7z l prebuilt.zip
   - cmd: 7z e prebuilt.zip -y > nul
+  - cmd: dir DeepFaceLab*
+  - cmd: xcopy deepfacelab DeepFaceLab*\_internal\deepfacelab  /O /X /E /H /K
+  - cmd: 7z a DeepFaceLab%ARCH%.zip DeepFaceLab\
 
 build: off
 
@@ -52,9 +47,8 @@ build: off
 #  # interpreter
 #  - '%PYTHON%\python.exe setup.py bdist_wheel'
 
-#artifacts:
-#  # bdist_wheel puts your built wheel in the dist directory
-#  - path: dist\*
+artifacts:
+  - path: DeepFaceLab%ARCH%.zip
 
 #on_success:
 #  You can use this step to upload your artifacts to a public website.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,11 +22,11 @@ install:
   - cmd: python deepfacelab\appveyor\gdrive.py %ARCH% > Output
   - cmd: set /p URL=<Output
   - ps: wget "$env:URL" -OutFile prebuilt.zip
-  - cmd: 7z l prebuilt.zip
+  #- cmd: 7z l prebuilt.zip
   - cmd: 7z e prebuilt.zip -y > nul
-  - cmd: dir DeepFaceLab*
+  #- cmd: dir DeepFaceLab*
   - cmd: xcopy deepfacelab DeepFaceLab*\_internal\deepfacelab  /O /X /E /H /K
-  - cmd: 7z a DeepFaceLab%ARCH%.zip DeepFaceLab\
+  - cmd: 7z a DeepFaceLab%ARCH%.7z -r DeepFaceLab\
 
 build: off
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,7 +25,7 @@ install:
   #- cmd: 7z l prebuilt.zip
   - cmd: 7z e prebuilt.zip -y > nul
   #- cmd: dir DeepFaceLab*
-  - cmd: xcopy .\deepfacelab .\DeepFaceLab*\_internal\deepfacelab\ /Y /O /X /E /H /K
+  - cmd: xcopy \deepfacelab \DeepFaceLab*\_internal\deepfacelab\ /Y /O /X /E /H /K
   - cmd: 7z a DeepFaceLab%ARCH%.7z -r DeepFaceLab*\
 
 build: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,10 +11,11 @@ version: '{branch}-{build}'
 
 install:
   # Download the latest prebuilt exe
-  - ps: python -m pip install -r appveyor/requirements.txt
+  - ps: pip install --user --upgrade pip
+  - ps: pip install --user -r appveyor/requirements.txt
   - ps: Set-Variable -Name "URL" -Value $(python appveyor/gdrive.py $ARCH)
   - ps: Write-Output $URL
-  - cmd: cd %home%
+  - cmd: cd ..
   - ps: wget $URL -OutFile prebuilt.zip
   - cmd: 7z e prebuilt.zip -y > nul
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,11 +15,13 @@ version: '{branch}-{build}'
 install:
   # Download the latest prebuilt exe
   - cmd: SET PATH=%PYTHON%;%PYTHON%\Scripts;%PATH%"
+  - cmd: python --version
   - ps: python -m pip install --upgrade pip
   - ps: python -m pip install -r appveyor/requirements.txt
-  - ps: Set-Variable -Name "URL" -Value $(python appveyor/gdrive.py $ARCH)
-  - ps: Write-Output $URL
   - cmd: cd ..
+  - cmd: python %home%/appveyor/gdrive.py %ARCH% > Output
+  - cmd: set /p URL=<Output
+  - cmd: %URL%
   - ps: wget $URL -OutFile prebuilt.zip
   - cmd: 7z e prebuilt.zip -y > nul
 

--- a/appveyor/gdrive.py
+++ b/appveyor/gdrive.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+import sys
+from operator import itemgetter
+import requests
+import re
+import datetime
+import os
+
+FOLDER_ID = os.environ['FOLDER_ID']
+API_KEY = os.environ['API_KEY']
+
+p = re.compile(r'DeepFaceLab([\w.]+)_build_(\d\d)_(\d\d)_(\d\d\d\d)\.exe')
+
+
+def get_folder_url(folder_id):
+    return "https://www.googleapis.com/drive/v3/files?q='" + folder_id + "'+in+parents&key=" + API_KEY
+
+
+def get_builds():
+    url = get_folder_url(FOLDER_ID)
+    r = requests.get(url)
+    files = r.json()['files']
+    builds = []
+    for file in files:
+        if file['mimeType'] == 'application/x-msdownload':
+            filename = file['name']
+            m = p.match(filename)
+            if m:
+                file['arch'], month, day, year = m.groups()
+                file['date'] = datetime.date(int(year), int(month), int(day))
+                builds.append(file)
+            else:
+                # print('Not parsed: ', filename)
+                pass
+    return builds
+
+
+def get_latest_build(arch):
+    builds = get_builds()
+    arch_builds = [build for build in builds if build['arch'] == arch]
+    arch_builds.sort(key=itemgetter('date'))
+    return arch_builds[-1]
+
+
+def get_download_url(file_id):
+    return "https://www.googleapis.com/drive/v3/files/" + file_id + "?alt=media&key=" + API_KEY
+
+
+def main():
+    arch = sys.argv[1]
+    print(arch)
+    latest_build = get_latest_build(arch)
+    # print(latest_build)
+    download_url = get_download_url(latest_build['id'])
+    print(download_url)
+
+
+if __name__ == "__main__":
+    main()

--- a/appveyor/gdrive.py
+++ b/appveyor/gdrive.py
@@ -48,7 +48,7 @@ def get_download_url(file_id):
 
 def main():
     arch = sys.argv[1]
-    print(arch)
+    # print(arch)
     latest_build = get_latest_build(arch)
     # print(latest_build)
     download_url = get_download_url(latest_build['id'])

--- a/appveyor/requirements.txt
+++ b/appveyor/requirements.txt
@@ -1,0 +1,1 @@
+requests


### PR DESCRIPTION
Sets up CI/CD in Appveyor to grabs the latest prebuilt images in GDrive for:
- OpenCLSSE|
- CUDA9.2SSE
- CUDA10.1SSE
- CUDA10.1AVX
Extracts the files, copies the forked version into the DeepFaceLab directory, then archives it and saves the artifact in Appveyor

Future enhancements may include:
- Installing other dependencies needed by our fork e.g.: `eos-py`
- Pushing builds to Github Releases
- Modifying the workspace with our own facesets e.g.: replace `celebA` with `celebA-HQ`
- Adding other executables, like Github Desktop