### PR TITLE
Silence the Tensorflow warnings for Tensorflow 1.14.

### DIFF
--- a/main.py
+++ b/main.py
@@ -7,9 +7,6 @@ from utils import Path_utils
 from utils import os_utils
 from pathlib import Path
 
-import tensorflow as tf
-tf.compat.v1.logging.set_verbosity(tf.compat.v1.logging.ERROR)
-
 if sys.version_info[0] < 3 or (sys.version_info[0] == 3 and sys.version_info[1] < 6):
     raise Exception("This program requires at least Python 3.6")
 

--- a/main.py
+++ b/main.py
@@ -7,6 +7,9 @@ from utils import Path_utils
 from utils import os_utils
 from pathlib import Path
 
+import tensorflow as tf
+tf.compat.v1.logging.set_verbosity(tf.compat.v1.logging.ERROR)
+
 if sys.version_info[0] < 3 or (sys.version_info[0] == 3 and sys.version_info[1] < 6):
     raise Exception("This program requires at least Python 3.6")
 

--- a/nnlib/nnlib.py
+++ b/nnlib/nnlib.py
@@ -151,6 +151,7 @@ NLayerDiscriminator = nnlib.NLayerDiscriminator
         warnings.simplefilter(action='ignore', category=FutureWarning)
 
         import tensorflow as tf
+        tf.compat.v1.logging.set_verbosity(tf.compat.v1.logging.ERROR)
         nnlib.tf = tf
 
         if device_config.cpu_only:

--- a/requirements-cpu.txt
+++ b/requirements-cpu.txt
@@ -1,4 +1,4 @@
-numpy==1.17.0
+numpy==1.16.4
 h5py==2.9.0
 Keras==2.2.4
 opencv-python==4.1.0.25

--- a/requirements-cuda.txt
+++ b/requirements-cuda.txt
@@ -1,4 +1,4 @@
-numpy==1.17.0
+numpy==1.16.4
 h5py==2.9.0
 Keras==2.2.4
 opencv-python==4.1.0.25

--- a/requirements-opencl.txt
+++ b/requirements-opencl.txt
@@ -1,4 +1,4 @@
-numpy==1.17.0
+numpy==1.16.4
 h5py==2.9.0
 Keras==2.2.4
 opencv-python==4.1.0.25


### PR DESCRIPTION
Use the matching numpy for tf==1.14, which is 1.16.4.
This silences the excessive warnings until upgrading to TensorFlow 2.