### PR TITLE
Adds option to increase the weight of src loss to dst loss

### DIFF
--- a/models/Model_SAEHD/Model.py
+++ b/models/Model_SAEHD/Model.py
@@ -61,7 +61,7 @@ class SAEHDModel(ModelBase):
             self.options['ae_dims'] = self.options.get('ae_dims', default_ae_dims)
             self.options['ed_ch_dims'] = self.options.get('ed_ch_dims', default_ed_ch_dims)
 
-        default_src_dst_loss_ratio = self.options.get('src_dst_loss_ratio', 50.0)
+        default_src_dst_loss_ratio = self.options.get('src_dst_loss_ratio', 1.0)
         default_background_power = self.options.get('background_power', 0.0)
         default_true_face_training = self.options.get('true_face_training', False)
         default_true_face_power = self.options.get('true_face_power', 1.0)
@@ -81,9 +81,9 @@ class SAEHDModel(ModelBase):
             #     def_absolute_loss,
             #     help_message="")
 
-            self.options['src_dst_loss_ratio'] = np.clip(io.input_number(f"Ratio of src to dst loss: ( 0.0 .. 100.0 ?:help skip:{default_src_dst_loss_ratio}) : ",
+            self.options['src_dst_loss_ratio'] = np.clip(io.input_number(f"Ratio of src to dst loss: ( 0.0 .. 2.0 ?:help skip:{default_src_dst_loss_ratio}) : ",
                                                                          default_src_dst_loss_ratio,
-                                                                         help_message="Allows you to skew the percentage of loss from src and dst. 50% means no change. E.g.: (75) -> loss = 75% src loss + 25% dst loss"), 0.0, 100.0)
+                                                                         help_message="Allows you to skew the percentage of loss from src and dst. 1 means no change. E.g.: (1.5) -> loss = 1.5 * src loss + 0.5 * dst loss"), 0.0, 2.0)
 
             self.options['background_power'] = np.clip(io.input_number(f"Background src/dst power ( 0.0 .. 100.0 ?:help skip:{default_background_power}) : ",
                                                                        default_background_power,
@@ -133,7 +133,7 @@ class SAEHDModel(ModelBase):
             self.options['ms_ssim_loss'] = self.options.get('ms_ssim_loss', True)
             self.options['absolute_loss'] = self.options.get('absolute_loss', False)
             self.options['random_warp'] = self.options.get('random_warp', True)
-            self.options['src_dst_loss_ratio'] = self.options.get('src_dst_loss_ratio', 50)
+            self.options['src_dst_loss_ratio'] = self.options.get('src_dst_loss_ratio', default_src_dst_loss_ratio)
             self.options['background_power'] = self.options.get('background_power', default_background_power)
             self.options['true_face_training'] = self.options.get('true_face_training', default_true_face_training)
             self.options['true_face_power'] = self.options.get('true_face_power', default_true_face_power)
@@ -550,8 +550,8 @@ class SAEHDModel(ModelBase):
                     src_loss += K.mean( (10*bg_style_power)*dssim(kernel_size=int(resolution/11.6),max_value=1.0)( psd_target_dst_anti_masked, target_dst_anti_masked ))
                     src_loss += K.mean( (10*bg_style_power)*K.square( psd_target_dst_anti_masked - target_dst_anti_masked ))
 
-            src_dst_loss_ratio = self.options['src_dst_loss_ratio'] / 100.0
-            G_loss = src_dst_loss_ratio * src_loss + (1-src_dst_loss_ratio) * dst_loss
+            src_dst_loss_ratio = self.options['src_dst_loss_ratio']
+            G_loss = src_dst_loss_ratio * src_loss + (2-src_dst_loss_ratio) * dst_loss
 
             if self.true_face_training:
                 def DLoss(labels,logits):
@@ -585,7 +585,7 @@ class SAEHDModel(ModelBase):
                     src_mask_loss = K.mean(K.square(self.model.target_srcm-self.model.pred_src_srcm))
                     dst_mask_loss = K.mean(K.square(self.model.target_dstm-self.model.pred_dst_dstm))
 
-                mask_loss = src_dst_loss_ratio * src_mask_loss + (1-src_dst_loss_ratio) * dst_mask_loss
+                mask_loss = src_dst_loss_ratio * src_mask_loss + (2-src_dst_loss_ratio) * dst_mask_loss
                 self.src_dst_mask_train = K.function ([self.model.warped_src, self.model.warped_dst, self.model.target_srcm, self.model.target_dstm],[src_mask_loss, dst_mask_loss], self.src_dst_mask_opt.get_updates(mask_loss, self.model.src_dst_mask_trainable_weights ) )
 
             if self.options['learn_mask']:

--- a/models/Model_SAEHD/Model.py
+++ b/models/Model_SAEHD/Model.py
@@ -61,7 +61,7 @@ class SAEHDModel(ModelBase):
             self.options['ae_dims'] = self.options.get('ae_dims', default_ae_dims)
             self.options['ed_ch_dims'] = self.options.get('ed_ch_dims', default_ed_ch_dims)
 
-        default_src_dst_loss_ratio = self.options.get('src_dst_loss_ratio', 1.0)
+        default_src_dst_loss_ratio = self.options.get('src_dst_loss_ratio', 50.0)
         default_background_power = self.options.get('background_power', 0.0)
         default_true_face_training = self.options.get('true_face_training', False)
         default_true_face_power = self.options.get('true_face_power', 1.0)
@@ -81,9 +81,9 @@ class SAEHDModel(ModelBase):
             #     def_absolute_loss,
             #     help_message="")
 
-            self.options['src_dst_loss_ratio'] = np.clip(io.input_number(f"Ratio of src to dst loss: ( 0.0 .. 2.0 ?:help skip:{default_src_dst_loss_ratio}) : ",
+            self.options['src_dst_loss_ratio'] = np.clip(io.input_number(f"Ratio of src to dst loss: ( 0.0 .. 100.0 ?:help skip:{default_src_dst_loss_ratio}) : ",
                                                                          default_src_dst_loss_ratio,
-                                                                         help_message="Allows you to skew the percentage of loss from src and dst. 1 means no change. E.g.: (1.5) -> loss = 1.5 * src loss + 0.5 * dst loss"), 0.0, 2.0)
+                                                                         help_message="Allows you to skew the percentage of loss from src and dst. 50% means no change. E.g.: (75) -> loss = 75% src loss + 25% dst loss"), 0.0, 100.0)
 
             self.options['background_power'] = np.clip(io.input_number(f"Background src/dst power ( 0.0 .. 100.0 ?:help skip:{default_background_power}) : ",
                                                                        default_background_power,
@@ -133,7 +133,7 @@ class SAEHDModel(ModelBase):
             self.options['ms_ssim_loss'] = self.options.get('ms_ssim_loss', True)
             self.options['absolute_loss'] = self.options.get('absolute_loss', False)
             self.options['random_warp'] = self.options.get('random_warp', True)
-            self.options['src_dst_loss_ratio'] = self.options.get('src_dst_loss_ratio', default_src_dst_loss_ratio)
+            self.options['src_dst_loss_ratio'] = self.options.get('src_dst_loss_ratio', 50)
             self.options['background_power'] = self.options.get('background_power', default_background_power)
             self.options['true_face_training'] = self.options.get('true_face_training', default_true_face_training)
             self.options['true_face_power'] = self.options.get('true_face_power', default_true_face_power)
@@ -550,8 +550,8 @@ class SAEHDModel(ModelBase):
                     src_loss += K.mean( (10*bg_style_power)*dssim(kernel_size=int(resolution/11.6),max_value=1.0)( psd_target_dst_anti_masked, target_dst_anti_masked ))
                     src_loss += K.mean( (10*bg_style_power)*K.square( psd_target_dst_anti_masked - target_dst_anti_masked ))
 
-            src_dst_loss_ratio = self.options['src_dst_loss_ratio']
-            G_loss = src_dst_loss_ratio * src_loss + (2-src_dst_loss_ratio) * dst_loss
+            src_dst_loss_ratio = self.options['src_dst_loss_ratio'] / 100.0
+            G_loss = src_dst_loss_ratio * src_loss + (1-src_dst_loss_ratio) * dst_loss
 
             if self.true_face_training:
                 def DLoss(labels,logits):
@@ -585,7 +585,7 @@ class SAEHDModel(ModelBase):
                     src_mask_loss = K.mean(K.square(self.model.target_srcm-self.model.pred_src_srcm))
                     dst_mask_loss = K.mean(K.square(self.model.target_dstm-self.model.pred_dst_dstm))
 
-                mask_loss = src_dst_loss_ratio * src_mask_loss + (2-src_dst_loss_ratio) * dst_mask_loss
+                mask_loss = src_dst_loss_ratio * src_mask_loss + (1-src_dst_loss_ratio) * dst_mask_loss
                 self.src_dst_mask_train = K.function ([self.model.warped_src, self.model.warped_dst, self.model.target_srcm, self.model.target_dstm],[src_mask_loss, dst_mask_loss], self.src_dst_mask_opt.get_updates(mask_loss, self.model.src_dst_mask_trainable_weights ) )
 
             if self.options['learn_mask']:


### PR DESCRIPTION
Modifies the total loss that's fed to the optimizer every iteration.
Instead of equally weighing the loss from src/dst, it allows you to weigh one more heavily.

![image](https://user-images.githubusercontent.com/1432270/71530151-3442f000-289d-11ea-83e0-491cdd46eddc.png)
By increasing the value >50, improvements in src loss are prioritized over improvements in dst loss

the NN's goal is to reduce the total error
so this feature doesn't change how we calculate src/dst loss
it just changes the calculation of the error given those losses
normally it's just src_loss + dst_loss
but by using this feature, you could skew it. e.g: 75% would give you 
"Error = 1.5 * src_loss + 0.5 * dst_loss"
the side-effect of this is the shared layers of SRC/DST should be geared more towards improving the SRC output
it's effect is somewhat similar to TrueFace, better likeness, but tracks the exact expression of the dst less closely
